### PR TITLE
FIX (dependencies): add peerDependencies as dependencies for npm >= 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,10 @@
     "typescript": "^2.2.1",
     "zone.js": "^0.7.4"
   },
+  "dependencies": {
+    "mobx": ">=2",
+    "@angular/core": ">=2.3.0"
+  }
   "peerDependencies": {
     "mobx": ">=2",
     "@angular/core": ">=2.3.0"

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   "dependencies": {
     "mobx": ">=2",
     "@angular/core": ">=2.3.0"
-  }
+  },
   "peerDependencies": {
     "mobx": ">=2",
     "@angular/core": ">=2.3.0"


### PR DESCRIPTION
add peerDependencies as dependencies to support npm >= 3 as per removal of support of _peerDependencies_ in npm >=3