### PR TITLE
Remove spread operator from module declaration (#112)

### DIFF
--- a/lib/mobx-angular.ts
+++ b/lib/mobx-angular.ts
@@ -23,8 +23,8 @@ const DIRECTIVES = [
   MobxReactionDirective
 ];
 @NgModule({
-  declarations: [...DIRECTIVES],
-  exports: [...DIRECTIVES],
+  declarations: DIRECTIVES,
+  exports: DIRECTIVES,
   imports: [],
   providers: []
 })


### PR DESCRIPTION
Make mobx-angular compatible with Angular 9 by removing the spread operator from module declaration. See: https://github.com/angular/angular/issues/29835
Related issue: #112 