### PR TITLE
Fix tictactoe compilation error

### DIFF
--- a/projects/tictactoe/src/app/components/cell/cell.component.ts
+++ b/projects/tictactoe/src/app/components/cell/cell.component.ts
@@ -3,7 +3,7 @@ import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
 @Component({
   selector: 'ttt-cell',
   template: `
-    <span class="cell-content" (click)="select.emit()">
+    <span class="cell-content" (click)="selectCell.emit()">
       <span *ngIf="value">{{ value }}</span>
       <span class="next-value" *ngIf="!value">{{ nextValue }}</span>
     </span>


### PR DESCRIPTION
Fix this issue after `npm run start tictactoe`:
```
ERROR in projects/tictactoe/src/app/components/cell/cell.component.ts:6:41 - error TS2339: Property 'select' does not exist on type 'CellComponent'.

6     <span class="cell-content" (click)="select.emit()">
                                          ~~~~~~
```