### PR TITLE
Detect project language as TypeScript, not HTML

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+projects/bank/* linguist-generated=true
+projects/bank/* linguist-vendored
+projects/tictactoe/* linguist-generated=true
+projects/tictactoe/* linguist-vendored
+projects/todo/* linguist-generated=true
+projects/todo/* linguist-vendored


### PR DESCRIPTION
Currently, the project's language is detected as HTML instead of TypeScript. This fix should bring TypeScript back.
![image](https://user-images.githubusercontent.com/22447849/74969277-52584700-542d-11ea-938f-4c9ca6e010b0.png)
