### PR TITLE
add required `makeObservable(this)` invocation to support decorators

### DIFF
--- a/projects/bank-v11/src/app/stores/account.store.ts
+++ b/projects/bank-v11/src/app/stores/account.store.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { observable, autorun, computed, action } from 'mobx';
+import { observable, autorun, computed, action, makeObservable } from 'mobx';
 import { sum } from 'lodash';
 
 @Injectable({ providedIn: 'root' })
@@ -7,6 +7,7 @@ export class Account {
   @observable transactions: number[] = [];
 
   constructor() {
+    makeObservable(this);
     if (localStorage.savedTransactions) {
       this.transactions = JSON.parse(localStorage.savedTransactions);
     }

--- a/projects/bank/src/app/stores/account.store.ts
+++ b/projects/bank/src/app/stores/account.store.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { observable, autorun, computed, action } from 'mobx';
+import { observable, autorun, computed, action, makeObservable } from 'mobx';
 import { sum } from 'lodash';
 
 @Injectable()
@@ -7,6 +7,7 @@ export class Account {
   @observable transactions: number[] = [];
 
   constructor() {
+    makeObservable(this);
     if (localStorage.savedTransactions) {
       this.transactions = JSON.parse(localStorage.savedTransactions);
     }

--- a/projects/tictactoe/src/app/services/game.store.ts
+++ b/projects/tictactoe/src/app/services/game.store.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { observable, action, computed, reaction } from 'mobx';
+import { observable, action, computed, reaction, makeObservable } from 'mobx';
 
 const OPONENT = {
   X: 'O',
@@ -13,6 +13,7 @@ export class GameStore {
   @observable firstPlayer = 'X';
 
   constructor() {
+    makeObservable(this);
     this.resetGame();
     this._countScore();
     this._changeStartingPlayer();

--- a/projects/todo/src/app/app.component.ts
+++ b/projects/todo/src/app/app.component.ts
@@ -1,6 +1,7 @@
 import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { observable, computed, action } from 'mobx-angular';
 import { Todos } from './stores/todos.store';
+import { makeObservable } from 'mobx';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -30,7 +31,9 @@ export class AppComponent {
     return [this.title];
   }
 
-  constructor(public todos: Todos) {}
+  constructor(public todos: Todos) {
+    makeObservable(this);
+  }
 
   @action.bound addTodo() {
     this.todos.addTodo({ title: this.title });

--- a/projects/todo/src/app/stores/todos.store.ts
+++ b/projects/todo/src/app/stores/todos.store.ts
@@ -1,4 +1,4 @@
-import { observable, computed, action, autorun, toJS } from 'mobx';
+import { observable, computed, action, autorun, toJS, makeObservable } from 'mobx';
 import { Injectable } from '@angular/core';
 
 export class Todo {
@@ -6,6 +6,7 @@ export class Todo {
   @observable title: string;
 
   constructor({ title, completed }) {
+    makeObservable(this);
     this.completed = completed;
     this.title = title;
   }
@@ -21,6 +22,7 @@ export class Todos {
   @observable filter = 'SHOW_ALL';
 
   constructor() {
+    makeObservable(this);
     this.localStorageSync();
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "declaration": false,
     "downlevelIteration": true,
     "experimentalDecorators": true,
+    "useDefineForClassFields": true,
     "module": "esnext",
     "moduleResolution": "node",
     "importHelpers": true,


### PR DESCRIPTION
Added `makeObservable(this);` as far as it is required since 6 versions of mobx.

https://mobx.js.org/enabling-decorators.html#enabling-decorators-