### PR TITLE
Support Angular 14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+<a name="4.6.0"></a>
+# 4.6.0 (2022-06-27)
+* Added support for Angular 14
+
 <a name="4.5.0"></a>
 # 4.5.0 (2022-01-05)
 * Update mobx-angular peerDependencies for Angular 13

--- a/projects/mobx-angular/package.json
+++ b/projects/mobx-angular/package.json
@@ -1,10 +1,10 @@
 {
   "name": "mobx-angular",
-  "version": "4.5.1",
+  "version": "4.6.0",
   "description": "Angular connector to MobX (2 and above)",
   "peerDependencies": {
-    "@angular/common": ">=11.1.1 <14.0.0",
-    "@angular/core": ">=11.1.1 <14.0.0",
+    "@angular/common": ">=11.1.1 <15.0.0",
+    "@angular/core": ">=11.1.1 <15.0.0",
     "mobx": ">=2",
     "tslib": "^2.0.0"
   },


### PR DESCRIPTION
Projects are blocked from using `mobx-angular` on Angular 14 if npm peer dependencies are strictly enforced. Tested locally, worked well.

Will need a maintainer to publish once merged.