### PR TITLE
Don't Limit Upper Angular Version

### DIFF
--- a/projects/mobx-angular/package.json
+++ b/projects/mobx-angular/package.json
@@ -1,10 +1,10 @@
 {
   "name": "mobx-angular",
-  "version": "4.7.1",
+  "version": "4.7.2",
   "description": "Angular connector to MobX (2 and above)",
   "peerDependencies": {
-    "@angular/common": ">=11.1.1 <16.0.0",
-    "@angular/core": ">=11.1.1 <16.0.0",
+    "@angular/common": ">=11.1.1",
+    "@angular/core": ">=11.1.1",
     "mobx": ">=2",
     "tslib": "^2.0.0"
   },


### PR DESCRIPTION
This will potentially prevent folks from having to remember to bump the max Angular version on every Angular major release.